### PR TITLE
Convert Newt_demo_pipeline_2019/Newt_demo_pipeline_2019-CI to GitHub Actions

### DIFF
--- a/.github/workflows/newt_demo_pipeline_2019-ci.yml
+++ b/.github/workflows/newt_demo_pipeline_2019-ci.yml
@@ -1,0 +1,16 @@
+name: Newt_demo_pipeline_2019/Newt_demo_pipeline_2019-CI
+on:
+  workflow_dispatch:
+env:
+  system_debug: 'false'
+jobs:
+  Job_1:
+    name: Agent job 1
+    runs-on:
+      - self-hosted
+      - Satya_pool
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - name: Command Line Script
+      run: echo hello

--- a/.github/workflows/newt_demo_pipeline_2019-ci.yml
+++ b/.github/workflows/newt_demo_pipeline_2019-ci.yml
@@ -6,7 +6,7 @@ env:
 jobs:
   Job_1:
     name: Agent job 1
-    runs-on:
+    runs-on: ubuntu-latest
       - self-hosted
       - Satya_pool
     steps:


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://ado.newtdevops.in/DefaultCollection/Newt_demo_pipeline_2019/_build?definitionId=68) :tada:

## Manual steps

Perform the following steps to complete the migration:

### Newt_demo_pipeline_2019/Newt_demo_pipeline_2019-CI
- [ ] Ensure a runner with the following labels exists: Satya_pool