### PR TITLE
Convert Newt_demo_pipeline_2019/MyPipelineFromYAML to GitHub Actions

### DIFF
--- a/.github/workflows/mypipelinefromyaml.yml
+++ b/.github/workflows/mypipelinefromyaml.yml
@@ -7,7 +7,7 @@ env:
   system_debug: 'false'
 jobs:
   build:
-    runs-on:
+    runs-on: ubuntu-latest
       - self-hosted
       - Satya_pool
     steps:

--- a/.github/workflows/mypipelinefromyaml.yml
+++ b/.github/workflows/mypipelinefromyaml.yml
@@ -1,0 +1,17 @@
+name: Newt_demo_pipeline_2019/MyPipelineFromYAML
+on:
+  push:
+    branches:
+    - "*"
+env:
+  system_debug: 'false'
+jobs:
+  build:
+    runs-on:
+      - self-hosted
+      - Satya_pool
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - name: Command Line Script
+      run: echo hello


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://ado.newtdevops.in/DefaultCollection/Newt_demo_pipeline_2019/_build?definitionId=78) :tada:

## Manual steps

Perform the following steps to complete the migration:

### Newt_demo_pipeline_2019/MyPipelineFromYAML
- [ ] Ensure a runner with the following labels exists: Satya_pool