### PR TITLE
Convert Newt_demo_pipeline_2019/TestRelease to GitHub Actions

### DIFF
--- a/.github/workflows/testrelease.yml
+++ b/.github/workflows/testrelease.yml
@@ -1,0 +1,13 @@
+name: Newt_demo_pipeline_2019/TestRelease
+on:
+  workflow_dispatch:
+env:
+  test: '1234'
+jobs:
+  Stage-1:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: "${{ github.ref }}"
+      cancel-in-progress: false
+    if: github.event_type != 'pull_request'
+    steps:


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://ado.newtdevops.in/DefaultCollection/Newt_demo_pipeline_2019/_release?_a=releases&definitionId=1) :tada: